### PR TITLE
Update Retrofit to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
   <properties>
     <vertx.version>3.5.4</vertx.version>
-    <retrofit.version>2.4.0</retrofit.version>
+    <retrofit.version>2.6.0</retrofit.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -57,11 +57,11 @@ Call<List<Repo>> repos = service.listRepos("octocat");
 <dependency>
   <groupId>com.julienviet</groupId>
   <artifactId>retrofit-vertx</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
 </dependency>
 ----
 
-This version is for Retrofit 2.4.0 and Vert.x 3.5.4
+This version is for Retrofit 2.6.0 and Vert.x 3.5.4
 
 == Going asynchronous
 

--- a/src/main/java/com/julienviet/retrofit/vertx/VertxCallFactory.java
+++ b/src/main/java/com/julienviet/retrofit/vertx/VertxCallFactory.java
@@ -15,6 +15,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
+import okio.Timeout;
 
 import java.io.IOException;
 import java.util.Map;
@@ -151,6 +152,11 @@ public class VertxCallFactory implements Call.Factory {
     @Override
     public boolean isCanceled() {
       return false;
+    }
+
+    @Override
+    public Timeout timeout() {
+      return Timeout.NONE;
     }
 
     @Override


### PR DESCRIPTION
Only real consideration here is that the OkHttp call requires a timeout method to be overridden,  which I've set to a constant of none which they provide. Though I believe this was the previous behaviour?